### PR TITLE
Row Selection

### DIFF
--- a/src/examples/App.tsx
+++ b/src/examples/App.tsx
@@ -24,7 +24,7 @@ const removeBodyClass = (className: string) => document.body.classList.remove(cl
 function App() {
   const [theme, setTheme] = React.useState('dark');
   const [theDb, setDB] = React.useState<SQLDatabase | null>(null);
-  const [selectedExample, setExample] = React.useState('Full');
+  const [selectedExample, setExample] = React.useState('ManualData');
 
   useEffect(() => {
     addBodyClass(theme);

--- a/src/examples/full/index.tsx
+++ b/src/examples/full/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataTable, TableActionButtonsProps } from '../../lib';
+import { DataTable, RowSelectorCheckboxProps, TableActionButtonsProps } from '../../lib';
 import { CommonColumns } from '../columns';
 import { DataState, onQueryChange, Pokemon, query, sqliteParams } from '../db';
 
@@ -17,7 +17,6 @@ export function FullFeaturedExample() {
     defaultSort={[
       {column: 'id', direction: 'asc'}
     ]}
-    canSelectRows={true}
     multiColumnSorts={true}
     canReorderColumns={true}
     paginateOptions={{
@@ -71,6 +70,13 @@ export function FullFeaturedExample() {
     DetailRow={({parentRow}) => <div>Detail row for {parentRow.name} goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisis commodo purus eget vehicula. Duis sodales sem orci, et pulvinar neque lacinia ut. Fusce in massa vel lorem consequat maximus nec ac lectus. In in elementum nulla. Quisque odio purus, euismod sed ullamcorper commodo, ullamcorper in ligula. Fusce sollicitudin pretium diam a facilisis. In fermentum, lectus quis efficitur suscipit, justo elit fermentum velit, in aliquet massa nisi suscipit ligula. Etiam volutpat id nulla at eleifend. Nulla tristique tellus ipsum, in gravida mauris ornare et. Mauris aliquet blandit risus ac ornare.</div>}
     canRowShowDetail={(data) => data.id !== 4}
 
+    canSelectRows={true}
+    canSelectRow={(data) => data.id !== 3}
+    onSelectionChange={(ids, rows) => {
+      // Probably store the selected in a state somewhere for use in an API call
+      console.log('Selected:', ids, rows);
+    }}
+
     columns={CommonColumns}
 
     onQueryChange={(queryProps) => onQueryChange(queryProps, setStaticData)} // Notifies of filter/pagination/search/sort changes
@@ -83,7 +89,8 @@ export function FullFeaturedExample() {
         ColumnPicker: CustomColPicker,
         Filter: CustomFilterBtn,
       },
-      ActionButtons: CustomActionButtons
+      ActionButtons: CustomActionButtons,
+      RowCheckbox: CustomCheckbox,
     }}
   />
 }
@@ -128,5 +135,20 @@ export class CustomActionButtons extends React.Component<TableActionButtonsProps
       {filter}
       {quickEdit}
     </>
+  }
+}
+
+export class CustomCheckbox extends React.Component<RowSelectorCheckboxProps> {
+  
+  render() {
+    const { checked, indeterminate, onChange } = this.props;
+    return <input
+      type='checkbox'
+      ref={(el) => el && (el.indeterminate = indeterminate)}
+      checked={checked}
+      onChange={onChange}
+      // inspect checkbox to see that custom is working
+      data-test={'custom-working'}
+    />;
   }
 }

--- a/src/lib/components/row-selector/index.tsx
+++ b/src/lib/components/row-selector/index.tsx
@@ -1,0 +1,73 @@
+import React, { useContext } from 'react';
+import { ColumnContext } from '../table/contexts';
+import { getRowKey } from '../../utils/getRowKey';
+
+interface RowSelectorProps {
+  row: any;
+  rowIndex: number;
+  data?: any[]
+}
+
+export const RowSelector: React.FC<RowSelectorProps> = ({ row, rowIndex, ...props }) => {
+  const {
+    actualColumns: columns,
+    canSelectRow,
+    getRowKey: propsGetRowKey,
+    selectedRows,
+    setRowSelected,
+    setAllSelected,
+    components,
+  } = useContext(ColumnContext);
+
+  const Checkbox = components?.RowCheckbox ?? RowSelectorCheckbox;
+
+  if (rowIndex < 0) {
+    // Select ALL
+    const rowData = props.data ?? [];
+    const filteredRowData = rowData.filter(rw => (typeof canSelectRow !== 'function' || canSelectRow(rw)));
+    const selectedKeys = Object.keys(selectedRows);
+
+    const isChecked = (!!filteredRowData.length && selectedKeys.length === filteredRowData.length);
+    const isIndeterminite = (!!filteredRowData.length && !!selectedKeys.length && filteredRowData.length !== selectedKeys.length);
+    return <div>
+      <Checkbox
+        checked={isChecked}
+        indeterminate={isIndeterminite}
+        onChange={() => {
+          if (!filteredRowData.length) return;
+          setAllSelected(!!filteredRowData.length && selectedKeys.length !== filteredRowData.length)
+        }}
+      />
+    </div>;
+  }
+
+  if (typeof canSelectRow === 'function' && !canSelectRow(row)) {
+    return <></>;
+  }
+
+  const rowKey = getRowKey(row, rowIndex, columns, propsGetRowKey)
+  const isSelected = typeof selectedRows[rowKey] !== 'undefined';
+
+  return <div>
+    <Checkbox
+      checked={isSelected}
+      indeterminate={false}
+      onChange={() => setRowSelected(row, rowIndex)}
+    />
+  </div>
+};
+
+export interface RowSelectorCheckboxProps {
+  checked: boolean
+  indeterminate: boolean
+  onChange: React.InputHTMLAttributes<HTMLInputElement>['onChange']
+}
+
+export const RowSelectorCheckbox: React.FC<RowSelectorCheckboxProps> = ({ indeterminate, checked, onChange }) => {
+  return <input
+    type='checkbox'
+    ref={(el) => el && (el.indeterminate = indeterminate)}
+    checked={checked}
+    onChange={onChange}
+  />;
+}

--- a/src/lib/components/table/contexts.ts
+++ b/src/lib/components/table/contexts.ts
@@ -32,7 +32,7 @@ interface ColumnContextInterface<T> {
   setFormData: React.Dispatch<React.SetStateAction<EditFormData>>;
   setColumnVisibility: (newState: (ColumnVisibilityStorage | ((state: ColumnVisibilityStorage) => ColumnVisibilityStorage))) => void;
   setColumnSort: (newState: ColumnSorts | ((state: ColumnSorts) => ColumnSorts)) => void;
-  setAllSelected: () => void;
+  setAllSelected: (selectAll: boolean) => void;
   setRowSelected: (row: T, rowIndex: number) => void;
   onShowColumnPicker?: OnShowColumnPicker;
   onShowFilterEditor?: OnShowFilterEditor;
@@ -45,6 +45,7 @@ interface ColumnContextInterface<T> {
   columnOrder: string[]
   setColumnOrder: (newState: string[] | ((state: string[]) => string[])) => void
   canReorderColumns: boolean
+  canSelectRow?: (row: T) => boolean;
   classNames?: CustomClasses
   labels?: CustomLabels
   components?: CustomComponents

--- a/src/lib/components/table/header.tsx
+++ b/src/lib/components/table/header.tsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
+import { RowSelector } from '../row-selector';
 import { ColumnContext } from './contexts';
 import { HeaderSort } from './sortable';
 import { ColumnSort } from './types';
 
 interface HeadProps {
   headRef: React.RefObject<HTMLTableSectionElement>
+  data: any[]
 }
 
 export const TableHeader: React.FC<HeadProps> = (props) => {
@@ -59,12 +61,16 @@ export const TableHeader: React.FC<HeadProps> = (props) => {
               }
             }
 
-            return (<>
+            return (<React.Fragment key={`row-key-${colIdx}`}>
               {(colIdx === 0 && rowIdx === 0) && <>
-                {hasDetailRenderer && <th scope='col' rowSpan={headerRows.length} className='fixed fixed-left mdr-control'>
+                {hasDetailRenderer && <th scope='col' key='mdr' rowSpan={headerRows.length} className='fixed fixed-left mdr-control'>
                 </th>}
-                {canSelectRows && <th scope='col' rowSpan={headerRows.length} className='fixed fixed-left mdr-control'>
-                  c
+                {canSelectRows && <th scope='col' key='sel' rowSpan={headerRows.length} className='fixed fixed-left row-selector'>
+                  <RowSelector
+                    row={null}
+                    rowIndex={-1}
+                    data={props.data}
+                  />
                 </th>}
               </>}
               <th key={colIdx} className={`${col.className ?? ''} ${col.fixed ? `fixed fixed-${col.fixed}` : ''}`.trim()} colSpan={col.colSpan > 1 ? col.colSpan : undefined} rowSpan={col.rowSpan > 1 ? col.rowSpan : undefined} scope={colScope}>
@@ -73,7 +79,7 @@ export const TableHeader: React.FC<HeadProps> = (props) => {
                   <HeaderSort column={col} sort={sort} />
                 </span>
               </th>
-            </>)
+            </React.Fragment>)
           })}
         </tr>
       ))}

--- a/src/lib/components/table/table-row.tsx
+++ b/src/lib/components/table/table-row.tsx
@@ -5,6 +5,7 @@ import { CellEditor } from './editors';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
+import { RowSelector } from '../row-selector';
 
 interface TableRowProps {
   row: any;
@@ -42,8 +43,8 @@ export const TableRow: React.FC<TableRowProps> = ({ row, ...props }) => {
           </button>
         </>}
       </td>}
-      {canSelectRows && <td key={`sel`} className='fixed fixed-left mdr-control'>
-        c
+      {canSelectRows && <td key={`sel`} className='fixed fixed-left row-selector'>
+        <RowSelector row={row} rowIndex={props.rowIndex} />
       </td>}
       {columns.map((col, colIdx) => {
         if (!col.isVisible) return null;
@@ -73,15 +74,14 @@ export const TableRow: React.FC<TableRowProps> = ({ row, ...props }) => {
           col.fixed ? `fixed fixed-${col.fixed}` : '',
         ].filter(s => !!s);
 
-        return <>
-          <td key={colIdx} className={classNames.join(' ').trim()}>
-            {rendered}
-          </td>
-        </>;
+        return <td key={colIdx} className={classNames.join(' ').trim()}>
+          {rendered}
+        </td>;
       })}
     </tr>
     {isExpanded && !!DetailRow && <tr>
-      <td className='fixed fixed-left mdr-control'></td>
+      {hasDetailRenderer && <td className='fixed fixed-left mdr-control'></td>}
+      {canSelectRows && <td className='fixed fixed-left row-selector'></td>}
       <td colSpan={columnCount}><DetailRowRenderer parentRow={row} /></td>
     </tr>}
   </>;

--- a/src/lib/components/table/types.ts
+++ b/src/lib/components/table/types.ts
@@ -11,6 +11,7 @@ import { SearchRequiredProps } from '../search/types';
 import { CustomFilterButtonProps, FilterSettings } from '../filter/types';
 import { CustomColumnPickerButtonProps } from '../column-picker/types';
 import { TableActionButtonsProps } from './actions';
+import { RowSelectorCheckboxProps } from '../row-selector';
 
 // export type EditFn<T> = (row: T, changes: Partial<T>) => Promise<boolean>;
 
@@ -48,7 +49,8 @@ export interface DataTableProperties<T> {
   hideSearchForm?: boolean;
 
   canSelectRows?: boolean;
-  onSelectionChange?: (selectedRows: any[]) => void;
+  canSelectRow?: (row: T) => boolean;
+  onSelectionChange?: (selectedIds: any[], selectedRows: T[]) => void;
 
   getRowKey?: (row: T) => string | number;
   canEditRow?: (row: T) => boolean;
@@ -82,6 +84,7 @@ export interface CustomComponents {
   SearchForm?: React.ElementType<SearchRequiredProps>;
   ActionButtons?: React.ElementType<TableActionButtonsProps>;
   Loading?: ReactRenderable;
+  RowCheckbox?: React.ElementType<RowSelectorCheckboxProps>;
   Buttons?: {
     ColumnPicker?: React.ElementType<CustomColumnPickerButtonProps>
     Filter?: React.ElementType<CustomFilterButtonProps>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,3 +13,6 @@ export type {
 export type {
   TableActionButtonsProps
 } from './components/table/actions';
+export type {
+  RowSelectorCheckboxProps
+} from './components/row-selector';

--- a/src/lib/style.scss
+++ b/src/lib/style.scss
@@ -64,6 +64,17 @@
     border-collapse: collapse;
 
     th, td {
+      &.row-selector {
+        padding-left: 0;
+        padding-right: 0;
+
+        > div {
+          width: var(--ts-selector-width, 25px);
+          display: inline-flex;
+          justify-content: center;
+        }
+      }
+
       &.fixed {
         position: sticky;
         background-clip: padding-box;
@@ -73,11 +84,20 @@
         &.fixed-right {
           right: 0;
         }
-        &.fixed-left:nth-child(1) {
+        &.fixed-left {
           left: 0;
-        }
-        &.fixed-left:nth-child(2) {
-          left: 1.5em;
+
+          &.mdr-control + .fixed-left {
+            left: 1.5em;
+          }
+
+          &.row-selector + .fixed-left {
+            left: var(--ts-selector-width, 25px); // unknown
+          }
+
+          &.mdr-control + .row-selector + .fixed-left {
+            left: calc(1.5em + var(--ts-selector-width, 25px)); // unknown
+          }
         }
 
         &:focus-within {


### PR DESCRIPTION
Re-evaulated #9 and determined it _was_ viable.

Enables selecting a row via a customizable checkbox (width determined by CSS variable so it can adjust left sticky position of adjacent column).