### PR TITLE
add tableCellProps and tableRowProps

### DIFF
--- a/src/demo/full/index.tsx
+++ b/src/demo/full/index.tsx
@@ -76,7 +76,22 @@ export function FullFeaturedExample() {
     canEditRow={(data) => data.id !== 7}
     DetailRow={({parentRow}) => <div>Detail row for {parentRow.name} goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisis commodo purus eget vehicula. Duis sodales sem orci, et pulvinar neque lacinia ut. Fusce in massa vel lorem consequat maximus nec ac lectus. In in elementum nulla. Quisque odio purus, euismod sed ullamcorper commodo, ullamcorper in ligula. Fusce sollicitudin pretium diam a facilisis. In fermentum, lectus quis efficitur suscipit, justo elit fermentum velit, in aliquet massa nisi suscipit ligula. Etiam volutpat id nulla at eleifend. Nulla tristique tellus ipsum, in gravida mauris ornare et. Mauris aliquet blandit risus ac ornare.</div>}
     canRowShowDetail={(data) => data.id !== 4}
-
+    tableRowProps={(row) => {
+      if(row.id === 1){
+        return {style: { backgroundColor: 'gray'}}
+      }
+    }}
+    tableCellProps={(column, row) => {
+      if(column.accessor === "id" && row.id === 1) {
+        return {
+          className: 'gold-border',
+          id: `td-top-id`,
+          style: {
+            textAlign: 'center',
+          }
+        }
+      }
+    }}
     canGroupBy={true}
     canSelectRows={true}
     canSelectRow={(data) => data.id !== 3}

--- a/src/demo/full/index.tsx
+++ b/src/demo/full/index.tsx
@@ -76,12 +76,12 @@ export function FullFeaturedExample() {
     canEditRow={(data) => data.id !== 7}
     DetailRow={({parentRow}) => <div>Detail row for {parentRow.name} goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisis commodo purus eget vehicula. Duis sodales sem orci, et pulvinar neque lacinia ut. Fusce in massa vel lorem consequat maximus nec ac lectus. In in elementum nulla. Quisque odio purus, euismod sed ullamcorper commodo, ullamcorper in ligula. Fusce sollicitudin pretium diam a facilisis. In fermentum, lectus quis efficitur suscipit, justo elit fermentum velit, in aliquet massa nisi suscipit ligula. Etiam volutpat id nulla at eleifend. Nulla tristique tellus ipsum, in gravida mauris ornare et. Mauris aliquet blandit risus ac ornare.</div>}
     canRowShowDetail={(data) => data.id !== 4}
-    tableRowProps={(row) => {
+    getTableRowProps={(row) => {
       if(row.id === 1){
         return {style: { backgroundColor: 'gray'}}
       }
     }}
-    tableCellProps={(column, row) => {
+    getTableCellProps={(column, row) => {
       if(column.accessor === "id" && row.id === 1) {
         return {
           className: 'gold-border',

--- a/src/demo/full/index.tsx
+++ b/src/demo/full/index.tsx
@@ -81,11 +81,10 @@ export function FullFeaturedExample() {
         return {style: { backgroundColor: 'gray'}}
       }
     }}
-    getTableCellProps={(column, row) => {
+    getTableCellProps={(_value, row, column) => {
       if(column.accessor === "id" && row.id === 1) {
         return {
           className: 'gold-border',
-          id: `td-top-id`,
           style: {
             textAlign: 'center',
           }

--- a/src/demo/style.scss
+++ b/src/demo/style.scss
@@ -91,4 +91,6 @@ code {
 
 .fw { width: 975px; }
 
+.gold-border { border: 2px solid gold;}
+
 @import '../library/style.scss';

--- a/src/library/components/table/contexts.ts
+++ b/src/library/components/table/contexts.ts
@@ -53,8 +53,8 @@ export interface ColumnContextInterface<T> {
   components?: CustomComponents
   groupsExpandedByDefault: boolean
   doNotUseHTML5Dialog?: boolean
-  tableRowProps?: (row: T) => (DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | undefined)
-  tableCellProps?: (column: DataColumn<T>, row: T) => (DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> | undefined)
+  getTableRowProps?: (row: T) => (DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | undefined)
+  getTableCellProps?: (column: DataColumn<T>, row: T) => (DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> | undefined)
 }
 
 export const ColumnContext = createContext<ColumnContextInterface<any>>({
@@ -82,8 +82,8 @@ export const ColumnContext = createContext<ColumnContextInterface<any>>({
   canReorderColumns: false,
   canGroupBy: false,
   groupsExpandedByDefault: true,
-  tableRowProps: () => undefined,
-  tableCellProps: () => undefined
+  getTableRowProps: () => undefined,
+  getTableCellProps: () => undefined
 });
 
 interface GroupCollapseContextInterface {

--- a/src/library/components/table/contexts.ts
+++ b/src/library/components/table/contexts.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, DetailedHTMLProps, TdHTMLAttributes, HTMLAttributes } from 'react';
 import {
   DataColumn,
   ColumnSorts,
@@ -53,6 +53,8 @@ export interface ColumnContextInterface<T> {
   components?: CustomComponents
   groupsExpandedByDefault: boolean
   doNotUseHTML5Dialog?: boolean
+  tableRowProps?: (row: T) => (DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | undefined)
+  tableCellProps?: (column: DataColumn<T>, row: T) => (DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> | undefined)
 }
 
 export const ColumnContext = createContext<ColumnContextInterface<any>>({
@@ -80,6 +82,8 @@ export const ColumnContext = createContext<ColumnContextInterface<any>>({
   canReorderColumns: false,
   canGroupBy: false,
   groupsExpandedByDefault: true,
+  tableRowProps: () => undefined,
+  tableCellProps: () => undefined
 });
 
 interface GroupCollapseContextInterface {

--- a/src/library/components/table/contexts.ts
+++ b/src/library/components/table/contexts.ts
@@ -54,7 +54,7 @@ export interface ColumnContextInterface<T> {
   groupsExpandedByDefault: boolean
   doNotUseHTML5Dialog?: boolean
   getTableRowProps?: (row: T) => (DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | undefined)
-  getTableCellProps?: (column: DataColumn<T>, row: T) => (DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> | undefined)
+  getTableCellProps?: (value: any, row: T, column: DataColumn<T>) => (DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> | undefined)
 }
 
 export const ColumnContext = createContext<ColumnContextInterface<any>>({

--- a/src/library/components/table/index.tsx
+++ b/src/library/components/table/index.tsx
@@ -466,8 +466,8 @@ export const DataTable = function DataTable<T>({paginate = 'both', quickEditPosi
       canSelectRow: props.canSelectRow,
       groupsExpandedByDefault: props.groupsExpandedByDefault ?? true,
       doNotUseHTML5Dialog: props.doNotUseHTML5Dialog,
-      tableRowProps: props.tableRowProps,
-      tableCellProps: props.tableCellProps
+      getTableRowProps: props.getTableRowProps,
+      getTableCellProps: props.getTableCellProps
     }}>
       <div id={props.id} style={wrapperStyle} {...(props.tableContainerProps ?? {})} className={`ts-datatable ts-datatable-container ${props.tableContainerProps?.className ?? ''}`}>
         <div ref={topEl} className={`ts-datatable-top`}>

--- a/src/library/components/table/index.tsx
+++ b/src/library/components/table/index.tsx
@@ -466,6 +466,8 @@ export const DataTable = function DataTable<T>({paginate = 'both', quickEditPosi
       canSelectRow: props.canSelectRow,
       groupsExpandedByDefault: props.groupsExpandedByDefault ?? true,
       doNotUseHTML5Dialog: props.doNotUseHTML5Dialog,
+      tableRowProps: props.tableRowProps,
+      tableCellProps: props.tableCellProps
     }}>
       <div id={props.id} style={wrapperStyle} {...(props.tableContainerProps ?? {})} className={`ts-datatable ts-datatable-container ${props.tableContainerProps?.className ?? ''}`}>
         <div ref={topEl} className={`ts-datatable-top`}>

--- a/src/library/components/table/table-row.tsx
+++ b/src/library/components/table/table-row.tsx
@@ -24,8 +24,8 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
     DetailRow,
     canRowShowDetail,
     canSelectRows,
-    tableRowProps,
-    tableCellProps
+    getTableRowProps,
+    getTableCellProps
   } = useContext(ColumnContext);
 
   let canEditRow = isEditing;
@@ -43,8 +43,8 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
   let rowStyle: any = {'--indent': group?.level ?? 0};
   let rowProps: DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> = {};
   
-  if (tableRowProps && typeof tableRowProps === 'function'){
-    rowProps = tableRowProps(row) ?? {};
+  if (getTableRowProps && typeof getTableRowProps === 'function'){
+    rowProps = getTableRowProps(row) ?? {};
 
     if (rowProps.style) {
       rowProps.style = {...rowProps.style, ...rowStyle};
@@ -91,8 +91,8 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
         let classNames: string[] = [col.className ?? '', col.fixed ? `fixed fixed-${col.fixed}` : ''];
         let cellProps: DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> = {};
         
-        if (tableCellProps && typeof tableCellProps === 'function'){
-          cellProps = tableCellProps(col, row) ?? {}
+        if (getTableCellProps && typeof getTableCellProps === 'function'){
+          cellProps = getTableCellProps(col, row) ?? {}
           if(cellProps.key) delete cellProps.key;
 
           if (cellProps.className) {

--- a/src/library/components/table/table-row.tsx
+++ b/src/library/components/table/table-row.tsx
@@ -93,7 +93,6 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
         
         if (getTableCellProps && typeof getTableCellProps === 'function'){
           cellProps = getTableCellProps(col, row) ?? {}
-          if(cellProps.key) delete cellProps.key;
 
           if (cellProps.className) {
             classNames.push(cellProps.className)
@@ -102,7 +101,7 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
           cellProps.className = classNames.join(' ').trim();
         }
         
-        return <td key={colIdx} {...cellProps}>{rendered}</td>;
+        return <td {...cellProps} key={colIdx}>{rendered}</td>;
       })}
     </tr>
     {isExpanded && !!DetailRow && <tr>

--- a/src/library/components/table/table-row.tsx
+++ b/src/library/components/table/table-row.tsx
@@ -98,7 +98,7 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
           if (cellProps.className) {
             classNames.push(cellProps.className)
           }
-          classNames.filter(s => !!s);
+          classNames = classNames.filter(s => !!s);
           cellProps.className = classNames.join(' ').trim();
         }
         

--- a/src/library/components/table/table-row.tsx
+++ b/src/library/components/table/table-row.tsx
@@ -92,7 +92,7 @@ export const TableRow = function TableRow<T>({ row, group, ...props }: TableRowP
         let cellProps: DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> = {};
         
         if (getTableCellProps && typeof getTableCellProps === 'function'){
-          cellProps = getTableCellProps(col, row) ?? {}
+          cellProps = getTableCellProps(rendered, row, col) ?? {}
 
           if (cellProps.className) {
             classNames.push(cellProps.className)

--- a/src/library/components/table/types.ts
+++ b/src/library/components/table/types.ts
@@ -68,8 +68,8 @@ export interface DataTableProperties<T> {
   tableContainerProps?: Omit<HTMLProps<HTMLDivElement>, 'id' | 'style'>;
   tableWrapperProps?: Omit<HTMLProps<HTMLDivElement>, 'id' | 'style'>;
   tableProps?: DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
-  tableRowProps?: (row: T) => DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
-  tableCellProps?: (column: DataColumn<T>, row: T) => DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>;
+  getTableRowProps?: (row: T) => DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+  getTableCellProps?: (column: DataColumn<T>, row: T) => DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>;
 
   fixedColBg?: string;
 

--- a/src/library/components/table/types.ts
+++ b/src/library/components/table/types.ts
@@ -2,6 +2,8 @@ import { ReactRenderable, ResolveProps } from '../../types';
 import {
   DetailedHTMLProps,
   TableHTMLAttributes,
+  TdHTMLAttributes,
+  HTMLAttributes,
   HTMLProps,
   ReactElement
 } from 'react';
@@ -66,6 +68,8 @@ export interface DataTableProperties<T> {
   tableContainerProps?: Omit<HTMLProps<HTMLDivElement>, 'id' | 'style'>;
   tableWrapperProps?: Omit<HTMLProps<HTMLDivElement>, 'id' | 'style'>;
   tableProps?: DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
+  tableRowProps?: (row: T) => DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+  tableCellProps?: (column: DataColumn<T>, row: T) => DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>;
 
   fixedColBg?: string;
 

--- a/src/library/components/table/types.ts
+++ b/src/library/components/table/types.ts
@@ -69,7 +69,7 @@ export interface DataTableProperties<T> {
   tableWrapperProps?: Omit<HTMLProps<HTMLDivElement>, 'id' | 'style'>;
   tableProps?: DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
   getTableRowProps?: (row: T) => DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
-  getTableCellProps?: (column: DataColumn<T>, row: T) => DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>;
+  getTableCellProps?: (value: any, row: T, column: DataColumn<T>) => DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>;
 
   fixedColBg?: string;
 

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -6,6 +6,7 @@ export type {
   CustomEditorProps,
   DataProps,
   DataColumnProp,
+  DataColumn
 } from './components/table/types';
 export type {
   TableActionButtonsProps


### PR DESCRIPTION
This supports styling rows and columns. 

Includes and update to the example showing how to use it.

tableCell/Row props passed to datatable:
![image](https://user-images.githubusercontent.com/12960453/133820719-a3915b62-9008-4bcd-ae9b-886ed73696d3.png)

result:
![image](https://user-images.githubusercontent.com/12960453/133820619-f042669d-8b22-4006-b0a3-7c414e4f0616.png)

I am deleting any "key" returned from the `tableCellProps()` function. I tried to omit it from the type but was not able to get it to work. I tried `Omit<DetailedHTMLProps<TdHTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>, 'key'>` and 2 or 3 other variations (with the omit at different levels) but could not get it to work.
